### PR TITLE
Two fixes

### DIFF
--- a/SteamAccCreator/Extension.cs
+++ b/SteamAccCreator/Extension.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace SteamAccCreator
+{
+    internal static class Extension
+    {
+        public static void InvokeIfRequired(this ISynchronizeInvoke obj, MethodInvoker action)
+        {
+            if (obj.InvokeRequired) {
+                var args = new object[0];
+                obj.Invoke(action, args);
+            } else {
+                action();
+            }
+        }
+    }
+}

--- a/SteamAccCreator/File/FileManager.cs
+++ b/SteamAccCreator/File/FileManager.cs
@@ -12,7 +12,7 @@ namespace SteamAccCreator.File
         {
             using (var writer = new StreamWriter(Path, true))
             {
-                writer.WriteLine(mail + ":" + pass);
+                writer.WriteLine($"{mail}\t{alias}\t{pass}");
             }
         }
     }

--- a/SteamAccCreator/Gui/AccountCreator.cs
+++ b/SteamAccCreator/Gui/AccountCreator.cs
@@ -106,7 +106,10 @@ namespace SteamAccCreator.Gui
             }
             else
             {
-                Clipboard.SetText(_mail);
+                _mainForm.InvokeIfRequired(() =>
+                {
+                    Clipboard.SetText(_mail);
+                });
             }
         }
 

--- a/SteamAccCreator/SteamAccCreator.csproj
+++ b/SteamAccCreator/SteamAccCreator.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extension.cs" />
     <Compile Include="Gui\CaptchaDialog.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
The clipboard action wasn't threadsafe and would throw a runtime error when called from any non-UI thread.
The WriteIntoFile function didn't save the alias. The writer also was colon delimited but since the passwords had a chance to contain a colon that didn't make much sense, tab delimited seemed like a better option.